### PR TITLE
Memory fragment

### DIFF
--- a/Assets/Animations/MemoryFragment.meta
+++ b/Assets/Animations/MemoryFragment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6c3c54120a48b74daa92ed947dfb1f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/MemoryFragment/Memory Fragment Disappear.anim
+++ b/Assets/Animations/MemoryFragment/Memory Fragment Disappear.anim
@@ -71,7 +71,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Animations/MemoryFragment/Memory Fragment Disappear.anim
+++ b/Assets/Animations/MemoryFragment/Memory Fragment Disappear.anim
@@ -1,0 +1,116 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Memory Fragment Disappear
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.6666666
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Color.a
+    path: PF Props Stone T1
+    classID: 212
+    script: {fileID: 0}
+  m_PPtrCurves: []
+  m_SampleRate: 12
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 394796625
+      attribute: 304273561
+      script: {fileID: 0}
+      typeID: 212
+      customType: 0
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.6666666
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.6666666
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Color.a
+    path: PF Props Stone T1
+    classID: 212
+    script: {fileID: 0}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/MemoryFragment/Memory Fragment Disappear.anim.meta
+++ b/Assets/Animations/MemoryFragment/Memory Fragment Disappear.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc7fddf8c27d40c44b64e4add064a72e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/MemoryFragment/Memory Fragment Idle.anim
+++ b/Assets/Animations/MemoryFragment/Memory Fragment Idle.anim
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Memory Fragment Idle
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/MemoryFragment/Memory Fragment Idle.anim.meta
+++ b/Assets/Animations/MemoryFragment/Memory Fragment Idle.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1705fe4c324156f4bbd790355beae217
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/MemoryFragment/Memory Fragment.controller
+++ b/Assets/Animations/MemoryFragment/Memory Fragment.controller
@@ -1,0 +1,12 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Memory Fragment
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers: []

--- a/Assets/Animations/MemoryFragment/Memory Fragment.controller
+++ b/Assets/Animations/MemoryFragment/Memory Fragment.controller
@@ -1,5 +1,58 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-8272300347841496317
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MemoryFragment
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: cc7fddf8c27d40c44b64e4add064a72e, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-5420434751126579562
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Memory Fragment Idle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 8641722506759109156}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 1705fe4c324156f4bbd790355beae217, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -8,5 +61,73 @@ AnimatorController:
   m_PrefabAsset: {fileID: 0}
   m_Name: Memory Fragment
   serializedVersion: 5
-  m_AnimatorParameters: []
-  m_AnimatorLayers: []
+  m_AnimatorParameters:
+  - m_Name: IsActivated
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: 7089161443865595374}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1107 &7089161443865595374
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -8272300347841496317}
+    m_Position: {x: 200, y: 0, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -5420434751126579562}
+    m_Position: {x: 210, y: 80, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 0, y: 10, z: 0}
+  m_EntryPosition: {x: 210, y: 160, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -5420434751126579562}
+--- !u!1101 &8641722506759109156
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsActivated
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8272300347841496317}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/Assets/Animations/MemoryFragment/Memory Fragment.controller.meta
+++ b/Assets/Animations/MemoryFragment/Memory Fragment.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf370b16d6bf07f4ead8c0c3aff69105
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Asset Packs/Cainos/Pixel Art Top Down - Basic/Prefab/Props/Memory Fragment.prefab
+++ b/Assets/Asset Packs/Cainos/Pixel Art Top Down - Basic/Prefab/Props/Memory Fragment.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &7947911505737750455
+--- !u!1 &1290375452346857160
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,8 +8,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7947911505737750448}
-  - component: {fileID: 7947911505737750450}
+  - component: {fileID: 1713233716467369757}
+  - component: {fileID: 4347260188099854767}
+  - component: {fileID: 6250444084423629797}
+  - component: {fileID: 1581895624730999579}
   m_Layer: 20
   m_Name: PF Props Stone T1
   m_TagString: Untagged
@@ -17,28 +19,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7947911505737750448
+--- !u!4 &1713233716467369757
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7947911505737750455}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_GameObject: {fileID: 1290375452346857160}
+  m_LocalRotation: {x: -0, y: -0, z: 0.69667256, w: 0.71738935}
+  m_LocalPosition: {x: 0.1653228, y: 0.025, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 7947911505844789837}
-  m_Father: {fileID: 0}
+  - {fileID: 8673320990657514337}
+  m_Father: {fileID: 5400177003831859580}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &7947911505737750450
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 88.321}
+--- !u!212 &4347260188099854767
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7947911505737750455}
+  m_GameObject: {fileID: 1290375452346857160}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -73,7 +75,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 2
   m_Sprite: {fileID: 21300102, guid: 29c9cded5e558164aaf8c9bf08aa1510, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.023584902, g: 0.55733144, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -83,7 +85,45 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 1
---- !u!1 &7947911505844789836
+--- !u!61 &6250444084423629797
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1290375452346857160}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.15625}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0}
+    oldSize: {x: 0.34375, y: 0.3125}
+    newSize: {x: 0.8125, y: 1.625}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.34375, y: 0.3125}
+  m_EdgeRadius: 0
+--- !u!114 &1581895624730999579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1290375452346857160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d4597c6f3ca17f48848834189fe7b55, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1945650900018221373
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -91,8 +131,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7947911505844789837}
-  - component: {fileID: 7947911505844789838}
+  - component: {fileID: 8673320990657514337}
+  - component: {fileID: 5058675441898274753}
   m_Layer: 20
   m_Name: Shadow
   m_TagString: Untagged
@@ -100,27 +140,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7947911505844789837
+--- !u!4 &8673320990657514337
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7947911505844789836}
+  m_GameObject: {fileID: 1945650900018221373}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.017, y: -0, z: 0.1}
+  m_LocalPosition: {x: -0.27, y: -0.008, z: 0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 7947911505737750448}
+  m_Father: {fileID: 1713233716467369757}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &7947911505844789838
+--- !u!212 &5058675441898274753
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7947911505844789836}
+  m_GameObject: {fileID: 1945650900018221373}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -165,3 +205,34 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 1
+--- !u!1 &4188748849957621654
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5400177003831859580}
+  m_Layer: 0
+  m_Name: Memory Fragment
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5400177003831859580
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4188748849957621654}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1713233716467369757}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Asset Packs/Cainos/Pixel Art Top Down - Basic/Prefab/Props/Memory Fragment.prefab.meta
+++ b/Assets/Asset Packs/Cainos/Pixel Art Top Down - Basic/Prefab/Props/Memory Fragment.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 43037714c380d974a95f0988c8efcd23
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Asset Packs/Cainos/Pixel Art Top Down - Basic/Script/PropsAltar.cs
+++ b/Assets/Asset Packs/Cainos/Pixel Art Top Down - Basic/Script/PropsAltar.cs
@@ -12,6 +12,7 @@ namespace Cainos.PixelArtTopDown_Basic
         public List<SpriteRenderer> runes;
         public LevelLoader _levelLoader;
         public float lerpSpeed;
+        public PlayerMovement PlayerMovement;
 
         private Color curColor;
         private Color targetColor;
@@ -45,7 +46,7 @@ namespace Cainos.PixelArtTopDown_Basic
             {
                 timeRemaining -= Time.deltaTime;
             }
-            else if(isStanding && timeRemaining <= 0)
+            else if (isStanding && timeRemaining <= 0 && PlayerMovement.IsAltarUnlocked)
             {
                 LoadLevelLoaderScene();
             }

--- a/Assets/MemoryFragment.cs
+++ b/Assets/MemoryFragment.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MemoryFragment : MonoBehaviour
+{
+    public Animator animator;
+
+    void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (!animator.GetBool("IsActivated")) animator.SetBool("IsActivated", true);
+        this.gameObject.GetComponent<BoxCollider2D>().enabled = false; // so that the character does not collide with the fading fragment
+    }
+}

--- a/Assets/MemoryFragment.cs
+++ b/Assets/MemoryFragment.cs
@@ -5,10 +5,36 @@ using UnityEngine;
 public class MemoryFragment : MonoBehaviour
 {
     public Animator animator;
+    public GameObject Dialog1;
+    public GameObject Dialog2;
+    public PlayerMovement PlayerMovement;
 
     void OnCollisionEnter2D(Collision2D collision)
     {
         if (!animator.GetBool("IsActivated")) animator.SetBool("IsActivated", true);
         this.gameObject.GetComponent<BoxCollider2D>().enabled = false; // so that the character does not collide with the fading fragment
+
+        Dialog1.SetActive(true);
+        PlayerMovement.SetControlEnabled(false);
+    }
+
+    public void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Return))
+        {
+            if (Dialog1.activeSelf)
+            {
+                Dialog1.SetActive(false);
+                Dialog2.SetActive(true);
+                return;
+            }
+            if (Dialog2.activeSelf)
+            {
+                Dialog2.SetActive(false);
+                PlayerMovement.SetControlEnabled(true);
+                PlayerMovement.SetAltarUnlocked(true);
+                return;
+            }
+        }
     }
 }

--- a/Assets/MemoryFragment.cs.meta
+++ b/Assets/MemoryFragment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d4597c6f3ca17f48848834189fe7b55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/ForestZone.unity
+++ b/Assets/Scenes/ForestZone.unity
@@ -3766,7 +3766,7 @@ Transform:
   - {fileID: 523037885}
   - {fileID: 847295064}
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &184039678
 PrefabInstance:
@@ -6722,7 +6722,7 @@ Transform:
   - {fileID: 65166116}
   - {fileID: 1858391851}
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &356324525 stripped
 Transform:
@@ -6873,8 +6873,9 @@ Transform:
   - {fileID: 1355055008}
   - {fileID: 6879985237197006734}
   - {fileID: 728043804}
+  - {fileID: 522261599}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &367060871 stripped
 Transform:
@@ -8671,6 +8672,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 39562e88b536753438a3153c5fbdf7b8, type: 3}
+--- !u!1 &490556907 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1290375452346857160, guid: 43037714c380d974a95f0988c8efcd23,
+    type: 3}
+  m_PrefabInstance: {fileID: 773305928}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &490556912
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 490556907}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: cf370b16d6bf07f4ead8c0c3aff69105, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1 &495864863
 GameObject:
   m_ObjectHideFlags: 0
@@ -8700,7 +8726,7 @@ Transform:
   m_Children:
   - {fileID: 243964981}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &498048217
 PrefabInstance:
@@ -9057,6 +9083,107 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 521047658}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &522261598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 522261599}
+  - component: {fileID: 522261602}
+  - component: {fileID: 522261601}
+  - component: {fileID: 522261600}
+  m_Layer: 0
+  m_Name: Memory Fragment Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &522261599
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522261598}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1827688686}
+  - {fileID: 2004765627}
+  m_Father: {fileID: 362920495}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &522261600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522261598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &522261601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522261598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &522261602
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522261598}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1001 &523037884
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9489,7 +9616,7 @@ PrefabInstance:
     - target: {fileID: 1020026546298814229, guid: 394ab9f45870510448379a37706f8d7e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1020026546298814229, guid: 394ab9f45870510448379a37706f8d7e,
         type: 3}
@@ -9659,6 +9786,178 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f681a54372d73d74785b9c9d4ac477e8, type: 3}
+--- !u!1001 &560677778
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 522261599}
+    m_Modifications:
+    - target: {fileID: 5942442753805480133, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480133, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480133, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 190.4165
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480133, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480135, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_Text
+      value: 'I feel as if I''m ... remembering something ...
+
+
+        My good friend
+        Kelou taught me how combining the fireball attack while slashing sets my
+        dagger into a fiery blaze. I also remember being able to move myself across
+        dimensions when next to a some sort of a portal.
+
+
+        If only I could
+        remember more...
+
+
+        (Press enter to continue)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480135, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_FontData.m_MinSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480135, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_FontData.m_FontSize
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863856, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_Name
+      value: Dialog Box 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863856, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 771.0188
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 241.39282
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.10005
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -175
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6, type: 3}
 --- !u!1001 &566886380
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13955,6 +14254,120 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1491182005}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &773305928
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1581895624730999579, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: Dialog1
+      value: 
+      objectReference: {fileID: 1827688685}
+    - target: {fileID: 1581895624730999579, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: Dialog2
+      value: 
+      objectReference: {fileID: 2004765626}
+    - target: {fileID: 1581895624730999579, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: animator
+      value: 
+      objectReference: {fileID: 1733398702}
+    - target: {fileID: 1581895624730999579, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: PlayerMovement
+      value: 
+      objectReference: {fileID: 484633428689802996}
+    - target: {fileID: 4188748849957621654, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_Name
+      value: Memory Fragment
+      objectReference: {fileID: 0}
+    - target: {fileID: 4347260188099854767, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4347260188099854767, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_SortingLayer
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4347260188099854767, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_SortingLayerID
+      value: -1903912189
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 30.43
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400177003831859580, guid: 43037714c380d974a95f0988c8efcd23,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 43037714c380d974a95f0988c8efcd23, type: 3}
 --- !u!1001 &774543420
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14273,7 +14686,7 @@ Transform:
   - {fileID: 8685503919767424082}
   - {fileID: 5310356309269155368}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &776929098 stripped
 Transform:
@@ -14920,7 +15333,7 @@ Transform:
   - {fileID: 694360313}
   - {fileID: 1473225611}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &795259849 stripped
 Transform:
@@ -17196,6 +17609,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: PauseMenuCanvas
       objectReference: {fileID: 0}
+    - target: {fileID: 6666640085309451159, guid: c15ce766dd1f5644cb4b18d056722508,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6666640085309451160, guid: c15ce766dd1f5644cb4b18d056722508,
         type: 3}
       propertyPath: m_Pivot.x
@@ -18317,6 +18735,11 @@ PrefabInstance:
       propertyPath: _levelLoader
       value: 
       objectReference: {fileID: 543594919}
+    - target: {fileID: 2440844624711060802, guid: c5bdca1933fde624698bb8c6d6daa44b,
+        type: 3}
+      propertyPath: PlayerMovement
+      value: 
+      objectReference: {fileID: 484633428689802996}
     - target: {fileID: 3644440869396892318, guid: c5bdca1933fde624698bb8c6d6daa44b,
         type: 3}
       propertyPath: m_Layer
@@ -18685,7 +19108,7 @@ RectTransform:
   m_Children:
   - {fileID: 813571315}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -19452,7 +19875,7 @@ Transform:
   - {fileID: 2016053410}
   - {fileID: 1072271753}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &990599597 stripped
 Transform:
@@ -20374,6 +20797,164 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5b94bf9107369684a8153921f763da38, type: 3}
+--- !u!1001 &1054841681
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 522261599}
+    m_Modifications:
+    - target: {fileID: 5942442753805480133, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480133, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480133, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480135, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_Text
+      value: 'You now know how to use the fiery sword attack! You can now also use
+        teleportation altars!
+
+
+        (Press enter to continue)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480135, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_FontData.m_MinSize
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442753805480135, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_FontData.m_FontSize
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863856, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_Name
+      value: Dialog Box 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863856, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 771.0188
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 178.99893
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.10005
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -143
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6, type: 3}
 --- !u!4 &1063959393 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2055102311959635375, guid: f681a54372d73d74785b9c9d4ac477e8,
@@ -20482,7 +21063,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1066340268
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20567,7 +21148,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1066340270
 MonoBehaviour:
@@ -26325,7 +26906,7 @@ PrefabInstance:
     - target: {fileID: 780457786116585093, guid: 21a2fd8672fcc294bb8190ca55401a34,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 780457786116585093, guid: 21a2fd8672fcc294bb8190ca55401a34,
         type: 3}
@@ -31438,6 +32019,31 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1804118273}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1733398700 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4188748849957621654, guid: 43037714c380d974a95f0988c8efcd23,
+    type: 3}
+  m_PrefabInstance: {fileID: 773305928}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &1733398702
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1733398700}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: cf370b16d6bf07f4ead8c0c3aff69105, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1001 &1744429039
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -32865,6 +33471,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 919940543}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1827688685 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5942442754674863856, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+    type: 3}
+  m_PrefabInstance: {fileID: 560677778}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1827688686 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+    type: 3}
+  m_PrefabInstance: {fileID: 560677778}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1828060209
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -34157,6 +34775,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: DeathMenuCanvas
       objectReference: {fileID: 0}
+    - target: {fileID: 5587139879184713052, guid: 798e2b9ee02c2a74d9d9db51246110d5,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 798e2b9ee02c2a74d9d9db51246110d5, type: 3}
 --- !u!1001 &1934243642
@@ -34913,7 +35536,7 @@ Transform:
   - {fileID: 950034291}
   - {fileID: 2038387882}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1965180683
 PrefabInstance:
@@ -122633,6 +123256,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f681a54372d73d74785b9c9d4ac477e8, type: 3}
+--- !u!1 &2004765626 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5942442754674863856, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1054841681}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &2004765627 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5942442754674863857, guid: f7d7aa2a9986349d2b94aa7f4aaa8ff6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1054841681}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2012594737
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -125908,17 +126543,17 @@ PrefabInstance:
     - target: {fileID: 484633429583499381, guid: e7ecca09af7b705478b4b0b4d58d1ed0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 484633429583499381, guid: e7ecca09af7b705478b4b0b4d58d1ed0,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -47.44
+      value: -11.7
       objectReference: {fileID: 0}
     - target: {fileID: 484633429583499381, guid: e7ecca09af7b705478b4b0b4d58d1ed0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 13.52
+      value: 30.22
       objectReference: {fileID: 0}
     - target: {fileID: 484633429583499381, guid: e7ecca09af7b705478b4b0b4d58d1ed0,
         type: 3}
@@ -126014,12 +126649,12 @@ PrefabInstance:
     - target: {fileID: 5310356309386136395, guid: 3b7f217699087654786d8f94c2d164ff,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -30.51978
+      value: 5.2202196
       objectReference: {fileID: 0}
     - target: {fileID: 5310356309386136395, guid: 3b7f217699087654786d8f94c2d164ff,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -12.497976
+      value: 4.2020226
       objectReference: {fileID: 0}
     - target: {fileID: 5310356309386136395, guid: 3b7f217699087654786d8f94c2d164ff,
         type: 3}
@@ -126148,6 +126783,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6879985238206875120, guid: 15f60f502ce14294ebe3c1e71aca8fe3,
         type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879985238206875120, guid: 15f60f502ce14294ebe3c1e71aca8fe3,
+        type: 3}
       propertyPath: m_TagString
       value: UI
       objectReference: {fileID: 0}
@@ -126179,12 +126819,12 @@ PrefabInstance:
     - target: {fileID: 8685503919481533649, guid: 35700bc98072a0d43b5aade33bfdacc0,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -23.928822
+      value: 5.2202196
       objectReference: {fileID: 0}
     - target: {fileID: 8685503919481533649, guid: 35700bc98072a0d43b5aade33bfdacc0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -12.510392
+      value: 4.2020226
       objectReference: {fileID: 0}
     - target: {fileID: 8685503919481533649, guid: 35700bc98072a0d43b5aade33bfdacc0,
         type: 3}

--- a/Assets/Scripts/PlayerScripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerMovement.cs
@@ -10,6 +10,7 @@ public class PlayerMovement : MonoBehaviour
     public bool _isControlEnabled = true;
     private Vector2 _movement = new Vector2();
 
+    private bool _isAltarUnlocked = false;
     private PlayerController playerController;
     // Start is called before the first frame update
     void Start()
@@ -28,7 +29,8 @@ public class PlayerMovement : MonoBehaviour
         animator.SetFloat("Vertical", _movement.y);
         animator.SetFloat("Horizontal", _movement.x);
 
-        if(animator.GetBool("IsMoving")){
+        if (animator.GetBool("IsMoving"))
+        {
             SoundManagerScript.PlaySound("playerMove");
         }
 
@@ -120,4 +122,7 @@ public class PlayerMovement : MonoBehaviour
 
     public bool IsControlEnabled() => _isControlEnabled;
 
+    public void SetAltarUnlocked(bool value) => _isAltarUnlocked = value;
+
+    public bool IsAltarUnlocked => _isAltarUnlocked;
 }


### PR DESCRIPTION
This PR adds a memory fragment in the forest zone.

This memory fragment shows a dialog with some made-up back story, which tells the user how to use a new skill. It also unlocks altar teleportation.

After this is approved, I'll move the player back to the starting point in forest zone and re-enable the tutorial 😄.

The fragment itself has a fade-out animation, which shows the fragment disappearing after collision, however this is not visible, since the dialog takes up all of the space 🤦.