### PR TITLE
Remix fix, 100% this time, fingers crossed

### DIFF
--- a/Assets/Scripts/PlayerScripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerController.cs
@@ -102,14 +102,17 @@ public class PlayerController : MonoBehaviour
         // Attack, spells and abilities.
         if (Input.GetButtonDown("Fire1") && !animator.GetBool("IsAttacking") && !animator.GetBool("IsCasting"))
         {
+            movement.ResetVelocity();
             Attack();
         }
         else if (Input.GetButtonDown("Spell1") && !animator.GetBool("IsAttacking"))
         {
+            movement.ResetVelocity();
             LaunchFireBall();
         }
         else if (Input.GetButtonDown("Dash") && !animator.GetBool("IsAttacking") && !animator.GetBool("IsCasting") && dashCanBeUsed)
         {
+            movement.ResetVelocity();
             if (currentStamina >= dashStaminaCost)
             {
                 SoundManagerScript.PlaySound("dash");


### PR DESCRIPTION
Made it so that the player's velocity is reset after any move or attack the player makes.
The player begins to float whenever the bug occurs and the player makes a move or attack. So, if we reset the player's velocity before the moves occur, there will be no floating. I think this is better than having the enemy reset the player's velocity when it attacks.